### PR TITLE
yay: add information on how to remove package

### DIFF
--- a/pages/linux/yay.md
+++ b/pages/linux/yay.md
@@ -20,6 +20,10 @@
 
 `yay -S {{package_name}}`
 
+- Remove an installed package:
+
+`yay -Rs {{package_name}}`
+
 - Search the package database for a keyword from the repos and AUR:
 
 `yay -Ss {{keyword}}`


### PR DESCRIPTION
Hello! Here's a PR for adding a line on how to remove a package with Yay.

- [x] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).

(fun fact: [this](https://github.com/Jguer/yay/issues/496) is currently the first search result for "how to remove a package yay", and isn't particularly helpful/healthy ;) )

